### PR TITLE
fix(lifecycle): treat cancellation during actor startup as graceful shutdown

### DIFF
--- a/lifecycle/lifecycle.go
+++ b/lifecycle/lifecycle.go
@@ -308,6 +308,8 @@ var errServiceCompleted = errors.New("service completed")
 // The cleanup is guaranteed to run even if any step fails,
 // using defer to ensure each started actor is properly stopped.
 // The ctx parameter controls the long-running monitoring process and can be used to cancel the entire operation.
+// Cancelling ctx is treated as a graceful shutdown request and Serve returns nil,
+// whether the cancellation arrives during actor startup or while monitoring services.
 func (lc *Lifecycle) Serve(ctx context.Context, ctors ...any) (xerr error) {
 	if !lc.served.CompareAndSwap(false, true) {
 		return errors.WithStack(ErrServed)
@@ -387,6 +389,15 @@ func (lc *Lifecycle) Serve(ctx context.Context, ctors ...any) (xerr error) {
 		logger.DebugContext(ctx, fmt.Sprintf("%s starting", actorType), "actor", actorName)
 
 		if err := actor.Start(ctx); err != nil {
+			// A shutdown request racing the startup sequence is a graceful
+			// shutdown, mirroring the run-phase handling of context.Canceled,
+			// not a startup failure. Checked via ctx.Err() rather than the
+			// returned error because the cancellation may be masked by
+			// intermediate layers (e.g. database drivers).
+			if errors.Is(ctx.Err(), context.Canceled) {
+				logger.InfoContext(ctx, fmt.Sprintf("%s startup aborted by shutdown request", actorType), "actor", actorName, "cause", err)
+				return nil
+			}
 			logger.ErrorContext(ctx, fmt.Sprintf("Failed to start %s", strings.ToLower(actorType)), "actor", actorName, "error", err)
 			return err
 		}

--- a/lifecycle/lifecycle_test.go
+++ b/lifecycle/lifecycle_test.go
@@ -222,6 +222,51 @@ func TestServeConvenienceFunction(t *testing.T) {
 	require.ErrorIs(t, err, ErrNoServices)
 }
 
+// TestServeCancelDuringActorStartup covers the race where a shutdown request
+// (context cancellation) arrives while an actor is still starting, e.g. a
+// SIGTERM racing a startup I/O call. Startup must treat it as a graceful
+// shutdown — mirroring the run-phase behavior — not as a startup failure.
+func TestServeCancelDuringActorStartup(t *testing.T) {
+	t.Run("cancellation during startup is graceful shutdown", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := Serve(ctx,
+			func(lc *Lifecycle) string {
+				lc.Add(NewFuncService(func(ctx context.Context) error {
+					<-ctx.Done()
+					return nil
+				}).WithName("background-service"))
+				lc.Add(NewFuncActor(func(ctx context.Context) error {
+					// Shutdown is requested while this actor is starting.
+					cancel()
+					return ctx.Err()
+				}, nil).WithName("starting-actor"))
+				return "ok"
+			},
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("real startup failure is still reported", func(t *testing.T) {
+		startErr := errors.New("dial failed")
+
+		err := Serve(context.Background(),
+			func(lc *Lifecycle) string {
+				lc.Add(NewFuncService(func(ctx context.Context) error {
+					<-ctx.Done()
+					return nil
+				}).WithName("background-service"))
+				lc.Add(NewFuncActor(func(_ context.Context) error {
+					return startErr
+				}, nil).WithName("failing-actor"))
+				return "ok"
+			},
+		)
+		require.ErrorIs(t, err, startErr)
+	})
+}
+
 // TestBuilderMethods tests all builder methods for comprehensive coverage
 func TestBuilderMethods(t *testing.T) {
 	lc := New()


### PR DESCRIPTION
Slack: https://theplant.slack.com/archives/C09H5U13GJY/p1783419772718129
## Problem

A shutdown request (context cancellation) that arrives while an actor is still starting is reported as a startup failure. The startup loop in `Serve` returns the actor's error unconditionally:

```go
if err := actor.Start(ctx); err != nil {
    logger.ErrorContext(...)
    return err
}
```

…while the run phase already treats `context.Canceled` as a clean exit:

```go
err := g.Wait()
if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, errServiceCompleted) {
    return nil
}
```

So the same shutdown signal is graceful if it lands one millisecond later, but a "failure" if it races the startup sequence.

## Real-world impact

- Flaky `TestHealthyEndpoints` in ciam-next ([failing run](https://github.com/theplant/ciam-next/actions/runs/28850523687/job/85564422521)): the test cancels the serve context right after health checks pass; when the cancel lands inside the challenge janitor's ~1.6ms seed-job enqueue transaction, `database/sql` aborts with `context canceled`, `Serve` reports it as `Failed to start service`, and the test fails.
- In production, a SIGTERM landing in the startup window makes the process exit non-zero, which K8s rolling updates read as a crash instead of a normal termination.

## Fix

Align the startup loop with the run-phase semantics: if the serve context has been cancelled, log the aborted actor at info level and return nil — the deferred cleanup stops already-started actors as usual.

Two deliberate choices:

- **Detect via `ctx.Err()`, not the returned error.** The cancellation may be masked by intermediate layers (database drivers can surface it as e.g. `driver: bad connection`), while "the serve context is cancelled" is unambiguous: once shutdown is requested, whatever `Start` returned is moot.
- **`context.DeadlineExceeded` still surfaces as an error**, matching the run phase (`TestServeConvenienceFunction` relies on this distinction).

## Testing

- New `TestServeCancelDuringActorStartup` reproduces the race deterministically (fails on `main`, passes with the fix) and pins that a real startup failure is still reported.
- Full suite + `go vet` + `golangci-lint run` (v2.11.3, same as CI): clean.
- Verified end-to-end against ciam-next via a local `replace`: `TestHealthyEndpoints` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
